### PR TITLE
Fixed use of '++' operator

### DIFF
--- a/src/oifile.jl
+++ b/src/oifile.jl
@@ -194,7 +194,7 @@ function read_datablock(hdu::HDU, hdr::FITSHeader; quiet::Bool=false)
             value = get_value(hdr, name, nothing)
             if value == nothing
                 warn("missing keyword \"$name\" in OI-FITS $dbtype data-block")
-                ++nerrs
+                nerrs += 1
             else
                 data[field] = value
             end
@@ -202,7 +202,7 @@ function read_datablock(hdu::HDU, hdr::FITSHeader; quiet::Bool=false)
             colnum = get(columns, name, 0)
             if colnum < 1
                 warn("missing column \"$name\" in OI-FITS $dbtype data-block")
-                ++nerrs
+                nerrs += 1
             else
                 data[field] = read_column(ff, colnum)
             end


### PR DESCRIPTION
Hello,

In my investigation for JuliaLang/julia#11686 I found a usage of `++` in your package, which I'm pretty sure was an incorrect translation from C/C++. Now that it's merged, it causes a syntax error, so hopefully this the correct functionality you were hoping to have.
